### PR TITLE
Fix smart refill continuation after first pickup is consumed

### DIFF
--- a/runtime/SmartHauling.Runtime.Tests/InvalidPickupRecoveryTests.cs
+++ b/runtime/SmartHauling.Runtime.Tests/InvalidPickupRecoveryTests.cs
@@ -22,7 +22,7 @@ public sealed class InvalidPickupRecoveryTests
     }
 
     [Fact]
-    public void CreatePlan_WhenCurrentTargetIsStaleButQueueHasEntries_DropsQueueHead()
+    public void CreatePlan_WhenCurrentTargetIsStaleButQueueHasEntries_KeepsQueueAndReleasesOnlyCurrent()
     {
         // Arrange
         var stale = new object();
@@ -36,7 +36,7 @@ public sealed class InvalidPickupRecoveryTests
 
         // Assert
         Assert.True(plan.ReleaseCurrentTarget);
-        Assert.Equal(0, plan.QueueIndexToDrop);
+        Assert.Equal(-1, plan.QueueIndexToDrop);
         Assert.True(plan.HasAnyAction);
     }
 

--- a/runtime/SmartHauling.Runtime/Execution/CoordinatedStockpileExecutor.cs
+++ b/runtime/SmartHauling.Runtime/Execution/CoordinatedStockpileExecutor.cs
@@ -392,10 +392,24 @@ internal static class CoordinatedStockpileExecutor
         }
 
         if (goal is not StockpileHaulingGoal stockpileGoal ||
-            !HaulSourcePolicy.ValidatePile(stockpileGoal, pile) ||
             !HaulSourcePolicy.CanReachPile(stockpileGoal, pile))
         {
             return false;
+        }
+
+        var validateSucceeded = HaulSourcePolicy.ValidatePile(stockpileGoal, pile);
+        var hasPlannedStorages = CoordinatedDropPlanLookup.TryGetPlannedStorages(goal, pile.BlueprintId, out var plannedStorages);
+        if (!validateSucceeded && !hasPlannedStorages)
+        {
+            return false;
+        }
+
+        if (!validateSucceeded)
+        {
+            DiagnosticTrace.Info(
+                "coord.exec",
+                $"Bypassed vanilla pickup validation for {goal.AgentOwner}: resource={pile.BlueprintId}, plannedStorages={plannedStorages.Count}",
+                120);
         }
 
         ForceTarget(goal, TargetIndex.A, nextTarget);

--- a/runtime/SmartHauling.Runtime/Execution/InvalidPickupRecovery.cs
+++ b/runtime/SmartHauling.Runtime/Execution/InvalidPickupRecovery.cs
@@ -38,9 +38,9 @@ internal static class InvalidPickupRecovery
                 }
             }
 
-            return queuedTargets.Count > 0
-                ? new InvalidPickupRecoveryPlan(releaseCurrentTarget: true, queueIndexToDrop: 0)
-                : new InvalidPickupRecoveryPlan(releaseCurrentTarget: true, queueIndexToDrop: -1);
+            // The current target is stale and does not match the queued intent.
+            // Release only the stale current target and keep queued candidates so decide() can promote them.
+            return new InvalidPickupRecoveryPlan(releaseCurrentTarget: true, queueIndexToDrop: -1);
         }
 
         return queuedTargets.Count > 0

--- a/runtime/SmartHauling.Runtime/Patches/Lifecycle/SafeUnloadRedirectPatch.cs
+++ b/runtime/SmartHauling.Runtime/Patches/Lifecycle/SafeUnloadRedirectPatch.cs
@@ -3,6 +3,7 @@ using HarmonyLib;
 using NSMedieval.Components;
 using NSMedieval.Controllers;
 using NSMedieval.Goap;
+using NSMedieval.Goap.Goals;
 using NSMedieval.State;
 using SmartHauling.Runtime.Goals;
 
@@ -54,7 +55,7 @@ internal static class SafeUnloadRedirectPatch
 
     [HarmonyPatch(typeof(WorkerGoapAgent), "OnGoalEnded")]
     [HarmonyPostfix]
-    private static void OnGoalEndedPostfix(WorkerGoapAgent __instance, Goal goal)
+    private static void OnGoalEndedPostfix(WorkerGoapAgent __instance, Goal goal, GoalCondition condition)
     {
         if (goal is SmartUnloadGoal)
         {
@@ -65,6 +66,7 @@ internal static class SafeUnloadRedirectPatch
         var context = PopContext(__instance, goal);
         if (context == null)
         {
+            TryRecoverNoDestinationCarry(__instance, goal, condition);
             return;
         }
 
@@ -238,6 +240,36 @@ internal static class SafeUnloadRedirectPatch
         }
 
         return UnloadExecutionPlanner.HasAnyUnloadDestination(goal, creature, storage, preferPlannedStorages: false);
+    }
+
+    private static void TryRecoverNoDestinationCarry(WorkerGoapAgent agent, Goal goal, GoalCondition condition)
+    {
+        if (!RuntimeActivation.IsActive ||
+            agent == null ||
+            agent.HasDisposed ||
+            LoadingController.IsSceneTransition ||
+            condition != GoalCondition.Incompletable ||
+            goal is not StockpileHaulingGoal ||
+            agent.AgentOwner is not CreatureBase creature ||
+            creature.HasDisposed ||
+            agent.AgentOwner is not IStorageAgent { Storage: not null } storageAgent)
+        {
+            return;
+        }
+
+        var storage = storageAgent.Storage;
+        var remaining = storage.GetTotalStoredCount();
+        if (remaining <= 0 || CanAttemptSmartUnload(agent, goal, creature, storage))
+        {
+            return;
+        }
+
+        DiagnosticTrace.Info(
+            "unload",
+            $"Dropping carry after incompletable {goal.GetType().Name} for {creature}: no storage candidate, carry={remaining}, carried=[{CarrySummaryUtil.Summarize(storage)}]",
+            20);
+        UnloadCarryContextStore.Clear(creature);
+        creature.DropStorage();
     }
 
     private sealed class GoalEndContext

--- a/runtime/SmartHauling.Runtime/Patches/Stockpile/HaulingDecisionTracePatch.cs
+++ b/runtime/SmartHauling.Runtime/Patches/Stockpile/HaulingDecisionTracePatch.cs
@@ -152,7 +152,7 @@ internal static class HaulingDecisionTracePatch
             StockpileDestinationPlanStore.Clear(__instance);
         }
 
-        ApplySmartPlanGuards(__instance, ref __result, isSmart, observed);
+        ApplySmartPlanGuards(__instance, creature, ref __result, isSmart, observed);
 
         var resultValue = __result;
         var decisionContext = HaulingDecisionTraceDiagnostics.BuildDecisionContext(__instance, observed.FirstPile, observed.FirstStorage);
@@ -278,20 +278,32 @@ internal static class HaulingDecisionTracePatch
 
     private static void ApplySmartPlanGuards(
         StockpileHaulingGoal goal,
+        CreatureBase? creature,
         ref bool result,
         bool isSmart,
         ObservedHaulPlanState observed)
     {
-        if (!isSmart || !result || observed.FirstPile == null)
+        if (!result || observed.FirstPile == null || creature == null)
         {
             return;
         }
 
-        if (goal.AgentOwner is CreatureBase owner &&
+        if (!HasViableDestinationForFirstPile(goal, creature, observed))
+        {
+            StockpileHaulingGoalState.ResetGoalState(goal);
+            DiagnosticTrace.Info(
+                "haul.find.result",
+                () => $"Rejected haul for {goal.AgentOwner}: no viable destination for seed={observed.ResourceSummary?.BlueprintId ?? "<none>"}",
+                120);
+            result = false;
+            return;
+        }
+
+        if (isSmart &&
+            goal.AgentOwner is CreatureBase owner &&
             !ClusterOwnershipStore.CanUsePile(owner, observed.FirstPile))
         {
-            goal.GetTargetQueue(TargetIndex.A).Clear();
-            goal.GetTargetQueue(TargetIndex.B).Clear();
+            StockpileHaulingGoalState.ResetGoalState(goal);
             DiagnosticTrace.Info(
                 "haul.find.result",
                 () => $"Rejected claimed haul for {goal.AgentOwner}: {observed.ResourceSummary?.BlueprintId ?? "<none>"}",
@@ -303,14 +315,43 @@ internal static class HaulingDecisionTracePatch
         if (observed.FirstStorage != null &&
             !HaulingPriorityRules.CanMoveToPriority(observed.EffectiveSourcePriority, observed.FirstStorage.Priority))
         {
-            goal.GetTargetQueue(TargetIndex.A).Clear();
-            goal.GetTargetQueue(TargetIndex.B).Clear();
+            StockpileHaulingGoalState.ResetGoalState(goal);
             DiagnosticTrace.Info(
                 "haul.find.result",
                 () => $"Rejected haul for {goal.AgentOwner}: {observed.ResourceSummary?.BlueprintId ?? "<none>"} sourcePriority={observed.EffectiveSourcePriority} targetPriority={observed.FirstStorage.Priority}",
                 120);
             result = false;
         }
+    }
+
+    private static bool HasViableDestinationForFirstPile(
+        StockpileHaulingGoal goal,
+        CreatureBase creature,
+        ObservedHaulPlanState observed)
+    {
+        var firstPile = observed.FirstPile;
+        if (firstPile == null || firstPile.HasDisposed)
+        {
+            return false;
+        }
+
+        var seedResource = firstPile.GetStoredResource();
+        if (seedResource == null || seedResource.HasDisposed)
+        {
+            return false;
+        }
+
+        var requestedAmount = Math.Max(1, Math.Min(seedResource.Amount, GetOptimisticPickupBudget(goal, seedResource.Blueprint)));
+        var candidatePlan = StorageCandidatePlanner.BuildPlan(
+            goal,
+            creature,
+            seedResource,
+            ZonePriority.None,
+            observed.EffectiveSourcePriority,
+            enablePriorityFallback: false,
+            requestedAmount,
+            preferredStorage: observed.FirstStorage);
+        return candidatePlan.Primary != null;
     }
 
     private static bool TryBuildHardPlan(StockpileHaulingGoal goal)
@@ -438,7 +479,7 @@ internal static class HaulingDecisionTracePatch
             return false;
         }
 
-        var pickupBudget = Math.Max(1, Mathf.Min(destinationBudget, requestedAmount));
+        var pickupBudget = Math.Max(1, requestedAmount);
         var sourcePatchPiles = BuildPlayerForcedSourcePatch(anchorPile);
         var prioritySeedPiles = BuildPlayerForcedPrioritySeedPiles(anchorPile, playerForcedIntent);
 
@@ -681,7 +722,7 @@ internal static class HaulingDecisionTracePatch
             return null;
         }
 
-        var pickupBudget = Math.Max(1, Mathf.Min(destinationBudget, requestedAmount));
+        var pickupBudget = Math.Max(1, requestedAmount);
         var score = HaulingScore.CalculateMaterializedSelectionScore(
             pickupBudget,
             requestedAmount,
@@ -785,20 +826,26 @@ internal static class HaulingDecisionTracePatch
 
     private static int GetOptimisticPickupBudget(StockpileHaulingGoal goal, Resource blueprint)
     {
-        if (goal.AgentOwner is IStorageAgent { Storage: not null } storageAgent && blueprint != null)
+        var fallbackBudget = Math.Max(1, StockpileHaulingGoalState.GetMaxCarryAmount(goal));
+        if (goal.AgentOwner is not IStorageAgent { Storage: not null } storageAgent)
         {
-            var projected = PickupPlanningUtil.GetProjectedCapacity(
-                storageAgent.Storage,
-                blueprint,
-                0f,
-                storageAgent.Storage.HasOneOrMoreResources());
-            if (projected > 0)
-            {
-                return projected;
-            }
+            return fallbackBudget;
         }
 
-        return Math.Max(1, StockpileHaulingGoalState.GetMaxCarryAmount(goal));
+        var storage = storageAgent.Storage;
+        var freeSpaceBudget = Math.Max(1, Mathf.FloorToInt(Math.Max(0f, storage.GetFreeSpace())));
+
+        var projectedBudget = blueprint != null
+            ? PickupPlanningUtil.GetProjectedCapacity(
+                storage,
+                blueprint,
+                0f,
+                storage.HasOneOrMoreResources())
+            : 0;
+
+        // Keep bag-fill planning robust even when the first seed is an equipment/single-item resource,
+        // where blueprint-projected capacity is often just 1.
+        return Math.Max(fallbackBudget, Math.Max(freeSpaceBudget, projectedBudget));
     }
 
     internal static string DescribeTaskSeeds(IEnumerable<StockpileTaskSeed> seeds, int maxSeeds = 6)

--- a/runtime/SmartHauling.Runtime/Patches/Stockpile/StockpileClusterAugmentor.cs
+++ b/runtime/SmartHauling.Runtime/Patches/Stockpile/StockpileClusterAugmentor.cs
@@ -90,7 +90,10 @@ internal static class StockpileClusterAugmentor
         var orderedCandidates = sameTypeSweep.OrderedCandidates;
 
         var optimisticPickupBudget = getOptimisticPickupBudget(goal, firstPile.Blueprint);
-        var pickupBudget = Math.Max(1, destinationCapacityBudget > 0 ? Mathf.Min(destinationCapacityBudget, optimisticPickupBudget) : optimisticPickupBudget);
+        // Do not cap pickup budget by the seed resource destination estimate.
+        // Mixed-resource destination planning trims unsupported/over-capacity resources later,
+        // so this keeps bag fill behavior high without regressing destination safety.
+        var pickupBudget = Math.Max(1, optimisticPickupBudget);
         var totalPlanned = 0;
         var plannedWeight = 0f;
         var plannedAny = storageAgent.Storage.HasOneOrMoreResources();


### PR DESCRIPTION
## Summary
- fix coordinated hauling refill continuation when the initial pile is consumed (stale current target recovery)
- allow smart-planned next pickup selection even when vanilla ValidatePile rejects, if a smart destination plan exists
- improve optimistic pickup budget so first-seed resource type does not collapse plan budget unexpectedly
- keep no-destination unload fallback for incompletable carry states

## Validation
- dotnet build .\\runtime\\SmartHauling.Runtime\\SmartHauling.Runtime.csproj -c Release
- dotnet test .\\runtime\\SmartHauling.Runtime.Tests\\SmartHauling.Runtime.Tests.csproj -c Release --no-build (125/125)

## Commit
- d19c1d3 (includes Co-authored-by: Codex <codex@openai.com>)